### PR TITLE
fix: when there is no flow_cred.json, ftp function cannot work.

### DIFF
--- a/src/advanced-ftp.js
+++ b/src/advanced-ftp.js
@@ -22,7 +22,7 @@ module.exports = function (RED) {
     //Funzione per la configurazione
     function AdvancedFtpNode(n) {
         RED.nodes.createNode(this, n);
-        var credentials = RED.nodes.getCredentials(n.id);
+        var credentials = RED.nodes.getCredentials(n.id) || {};
         this.options = {
             'host': n.host || 'localhost',
             'port': n.port || 21,


### PR DESCRIPTION
add the default value for credentials, avoid credentials.password trigger the exception of undefined object w/o password.

#12