### PR TITLE
Add putrename Operation and sendError option

### DIFF
--- a/src/advanced-ftp.html
+++ b/src/advanced-ftp.html
@@ -436,6 +436,7 @@ limitations under the License.
       <option value="site">SITE</option>
       <option value="size">SIZE</option>
       <option value="lastMod">LAST MOD</option>
+      <option value="putrename">PUTRENAME</option>
     </select>
   </div>
   <div class="form-row">
@@ -616,6 +617,16 @@ limitations under the License.
           command.show();
           recursive.hide();
           useCompression.hide();
+        }
+        else if (id == 'putrename') {
+          filename.show();
+          localFilename.show();
+          workingDir.hide();
+          oldPath.hide();
+          newPath.show();
+          command.hide();
+          recursive.hide();
+          useCompression.show();
         }
         else {
           filename.show();

--- a/src/advanced-ftp.html
+++ b/src/advanced-ftp.html
@@ -256,6 +256,8 @@ limitations under the License.
 <dd>determines whether errors are to be handled by the status node.</dd>
 <dt class="optional">throwError <span class="property-type">boolean</span></dt>
 <dd>determines whether errors are to be handled by the catch node.</dd>
+<dt class="optional">sendError <span class="property-type">boolean</span></dt>
+<dd>determines whether errors are send to the output.</dd>
 </dl>
 <h3>Outputs</h3>
 <ol class="node-ports">
@@ -478,6 +480,10 @@ limitations under the License.
     <label for="node-input-useCompression"><i class="fa fa-file-archive-o"></i> Use Compression</label>
     <input type="checkbox" id="node-input-useCompression">
   </div>
+  <div class="form-row input-sendError-row">
+    <label for="node-input-sendError"><i class="fa fa-file-circle-exclamation"></i> Send Error</label>
+    <input type="checkbox" id="node-input-sendError">
+  </div>
   <div class="form-row input-throwError-row">
     <label for="node-input-throwError"><i class="fa fa-exclamation-triangle"></i> Throw Error</label>
     <input type="checkbox" id="node-input-throwError">
@@ -510,6 +516,7 @@ limitations under the License.
       command: { value: '' },
       recursive: { value: false },
       useCompression: { value: false },
+      sendError: { value: false },
       throwError: { value: false },
       showError: { value: true },
       name: { value: '' }

--- a/src/advanced-ftp.html
+++ b/src/advanced-ftp.html
@@ -481,7 +481,7 @@ limitations under the License.
     <input type="checkbox" id="node-input-useCompression">
   </div>
   <div class="form-row input-sendError-row">
-    <label for="node-input-sendError"><i class="fa fa-file-circle-exclamation"></i> Send Error</label>
+    <label for="node-input-sendError"><i class="fa fa-exclamation"></i> Send Error</label>
     <input type="checkbox" id="node-input-sendError">
   </div>
   <div class="form-row input-throwError-row">

--- a/src/advanced-ftp.js
+++ b/src/advanced-ftp.js
@@ -275,7 +275,7 @@ module.exports = function (RED) {
                             break;
                         case 'putrename':
                             if (filename === '' || localFilename === '' || newPath === '') {
-                                if (throwError) node.error("Invalid Parameters for " + operation.toLocaleUpperCase());
+                                if (throwError) node.error("Invalid Parameters for " + operation.toLocaleUpperCase() + " : filename: " + filename + " localfilename:" + localFilename + " newPath:" + newPath);
                                 if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + " :Invalid Parameters" });
                                 return;
                             }

--- a/src/advanced-ftp.js
+++ b/src/advanced-ftp.js
@@ -423,11 +423,18 @@ module.exports = function (RED) {
                             return;
                         }
 
-                        if (operation == 'rename' || operation == 'putrename') {
+                        if (operation == 'rename') {
                             conn.end();
                             node.status({ fill: 'green', shape: 'ring', text: 'RENAME Successful' });
                             msg.payload = 'RENAME operation successful.';
                             msg.oldPath = oldPath;
+                            msg.newPath = newPath;
+                        }
+                        if (operation == 'putrename') {
+                            conn.end();
+                            node.status({ fill: 'green', shape: 'ring', text: 'RENAME Successful' });
+                            msg.payload = 'RENAME operation successful.';
+                            msg.filename = oldPath;
                             msg.newPath = newPath;
                         }
 

--- a/src/advanced-ftp.js
+++ b/src/advanced-ftp.js
@@ -615,7 +615,7 @@ module.exports = function (RED) {
                                 break;
                             case 'putrename':
                                 conn.put(localFilename, filename, useCompression, node.sendMsg);
-                                conn.rename(oldPath, newPath, node.sendPaths);
+                                conn.rename(filename, newPath, node.sendPaths);
                                 break;
                         }
                     });

--- a/src/advanced-ftp.js
+++ b/src/advanced-ftp.js
@@ -433,7 +433,7 @@ module.exports = function (RED) {
                         if (operation == 'putrename') {
                             conn.end();
                             node.status({ fill: 'green', shape: 'ring', text: 'RENAME Successful' });
-                            msg.payload = 'RENAME operation successful.';
+                            msg.payload = 'RENAME of PUTRENAME operation successful.';
                             msg.filename = oldPath;
                             msg.newPath = newPath;
                         }

--- a/src/advanced-ftp.js
+++ b/src/advanced-ftp.js
@@ -58,6 +58,7 @@ module.exports = function (RED) {
         this.newPath = n.newPath
         this.useCompression = n.useCompression;
         this.recursive = n.recursive;
+        this.sendError = n.sendError;
         this.throwError = n.throwError;
         this.showError = n.showError;
         this.ftpConfig = RED.nodes.getNode(this.ftp);
@@ -141,6 +142,13 @@ module.exports = function (RED) {
                     useCompression = msg.useCompression;
                 }
 
+                // The msg.sendError takes precedence over the sendError set in the node
+                var sendError = node.sendError;
+
+                if ((msg.sendError !== undefined) && (typeof msg.sendError === 'boolean')) {
+                    sendError = msg.sendError;
+                }
+
                 // The msg.showError takes precedence over the showError set in the node
                 var showError = node.showError;
 
@@ -174,6 +182,12 @@ module.exports = function (RED) {
                             if (throwError) node.error(err, msg);
                         }
                         if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + ' Failed' });
+                        if (sendError) {
+                            msg.error = err;
+                            msg.payload = 'Operation Aborted';
+                            msg.success = false;
+                            send(msg);
+                        }
                         return;
                     }
 
@@ -215,6 +229,12 @@ module.exports = function (RED) {
                             if (command === '') {
                                 if (throwError) node.error("Invalid Parameters for " + operation.toLocaleUpperCase());
                                 if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + " :Invalid Parameters" });
+                                if (sendError) {
+                                    msg.error = "Invalid Parameters for " + operation.toLocaleUpperCase();
+                                    msg.payload = 'Operation Aborted';
+                                    msg.success = false;
+                                    send(msg);
+                                }
                                 return;
                             }
                             break;
@@ -222,6 +242,12 @@ module.exports = function (RED) {
                             if (filename === '' || localFilename === '') {
                                 if (throwError) node.error("Invalid Parameters for " + operation.toLocaleUpperCase());
                                 if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + " :Invalid Parameters" });
+                                if (sendError) {
+                                    msg.error = "Invalid Parameters for " + operation.toLocaleUpperCase();
+                                    msg.payload = 'Operation Aborted';
+                                    msg.success = false;
+                                    send(msg);
+                                }
                                 return;
                             }
                             break;
@@ -229,6 +255,12 @@ module.exports = function (RED) {
                             if (filename === '' || localFilename === '') {
                                 if (throwError) node.error("Invalid Parameters for " + operation.toLocaleUpperCase());
                                 if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + " :Invalid Parameters" });
+                                if (sendError) {
+                                    msg.error = "Invalid Parameters for " + operation.toLocaleUpperCase();
+                                    msg.payload = 'Operation Aborted';
+                                    msg.success = false;
+                                    send(msg);
+                                }
                                 return;
                             }
                             break;
@@ -236,6 +268,12 @@ module.exports = function (RED) {
                             if (filename === '' || localFilename === '') {
                                 if (throwError) node.error("Invalid Parameters for " + operation.toLocaleUpperCase());
                                 if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + " :Invalid Parameters" });
+                                if (sendError) {
+                                    msg.error = "Invalid Parameters for " + operation.toLocaleUpperCase();
+                                    msg.payload = 'Operation Aborted';
+                                    msg.success = false;
+                                    send(msg);
+                                }
                                 return;
                             }
                             break;
@@ -243,6 +281,12 @@ module.exports = function (RED) {
                             if (oldPath === '' || newPath === '') {
                                 if (throwError) node.error("Invalid Parameters for " + operation.toLocaleUpperCase());
                                 if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + " :Invalid Parameters" });
+                                if (sendError) {
+                                    msg.error = "Invalid Parameters for " + operation.toLocaleUpperCase();
+                                    msg.payload = 'Operation Aborted';
+                                    msg.success = false;
+                                    send(msg);
+                                }
                                 return;
                             }
                             break;
@@ -250,6 +294,12 @@ module.exports = function (RED) {
                             if (newPath === '') {
                                 if (throwError) node.error("Invalid Parameters for " + operation.toLocaleUpperCase());
                                 if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + " :Invalid Parameters" });
+                                if (sendError) {
+                                    msg.error = "Invalid Parameters for " + operation.toLocaleUpperCase();
+                                    msg.payload = 'Operation Aborted';
+                                    msg.success = false;
+                                    send(msg);
+                                }
                                 return;
                             }
                             break;
@@ -257,6 +307,12 @@ module.exports = function (RED) {
                             if (oldPath === '') {
                                 if (throwError) node.error("Invalid Parameters for " + operation.toLocaleUpperCase());
                                 if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + " :Invalid Parameters" });
+                                if (sendError) {
+                                    msg.error = "Invalid Parameters for " + operation.toLocaleUpperCase();
+                                    msg.payload = 'Operation Aborted';
+                                    msg.success = false;
+                                    send(msg);
+                                }
                                 return;
                             }
                             break;
@@ -264,6 +320,12 @@ module.exports = function (RED) {
                             if (filename === '') {
                                 if (throwError) node.error("Invalid Parameters for " + operation.toLocaleUpperCase());
                                 if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + " :Invalid Parameters" });
+                                if (sendError) {
+                                    msg.error = "Invalid Parameters for " + operation.toLocaleUpperCase();
+                                    msg.payload = 'Operation Aborted';
+                                    msg.success = false;
+                                    send(msg);
+                                }
                                 return;
                             }
                             break;
@@ -277,12 +339,24 @@ module.exports = function (RED) {
                             if (filename === '' || localFilename === '' || newPath === '') {
                                 if (throwError) node.error("Invalid Parameters for " + operation.toLocaleUpperCase() + " : filename: " + filename + " localfilename:" + localFilename + " newPath:" + newPath);
                                 if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + " :Invalid Parameters" });
+                                if (sendError) {
+                                    msg.error = "Invalid Parameters for " + operation.toLocaleUpperCase();
+                                    msg.payload = 'Operation Aborted';
+                                    msg.success = false;
+                                    send(msg);
+                                }
                                 return;
                             }
                             break;
                         default:
                             if (throwError) node.error("Invalid Command");
                             if (showError) node.status({ fill: 'red', shape: 'ring', text: "Invalid Operation" });
+                            if (sendError) {
+                                msg.error = "Invalid Command";
+                                msg.payload = 'Operation Aborted';
+                                msg.success = false;
+                                send(msg);
+                            }
                             return;
                     }
 
@@ -301,6 +375,12 @@ module.exports = function (RED) {
                                 if (throwError) node.error(err, msg);
                             }
                             if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + ' Failed' });
+                            if (sendError) {
+                                msg.error = err;
+                                msg.payload = operation.toLocaleUpperCase() + ' Failed';
+                                msg.success = false;
+                                send(msg);
+                            }
                             conn.end();
                             return;
                         }
@@ -390,6 +470,12 @@ module.exports = function (RED) {
                                 if (throwError) node.error(err, msg);
                             }
                             if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + ' Failed' });
+                            if (sendError) {
+                                msg.error = err;
+                                msg.payload = operation.toLocaleUpperCase() + ' Failed';
+                                msg.success = false;
+                                send(msg);
+                            }
                             conn.end();
                             return;
                         }
@@ -419,6 +505,12 @@ module.exports = function (RED) {
                                 if (throwError) node.error(err, msg);
                             }
                             if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + ' Failed' });
+                            if (sendError) {
+                                msg.error = err;
+                                msg.payload = operation.toLocaleUpperCase() + ' Failed';
+                                msg.success = false;
+                                send(msg);
+                            }
                             conn.end();
                             return;
                         }
@@ -459,6 +551,12 @@ module.exports = function (RED) {
                                 if (throwError) node.error(err, msg);
                             }
                             if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + ' Failed' });
+                            if (sendError) {
+                                msg.error = err;
+                                msg.payload = operation.toLocaleUpperCase() + ' Failed';
+                                msg.success = false;
+                                send(msg);
+                            }
                             conn.end();
                             return;
                         }
@@ -476,6 +574,12 @@ module.exports = function (RED) {
                                 if (throwError) node.error(err, msg);
                             }
                             if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + ' Failed' });
+                            if (sendError) {
+                                msg.error = err;
+                                msg.payload = operation.toLocaleUpperCase() + ' Failed';
+                                msg.success = false;
+                                send(msg);
+                            }
                             conn.end();
                             return;
                         }
@@ -500,6 +604,12 @@ module.exports = function (RED) {
                                 if (throwError) node.error(err, msg);
                             }
                             if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + ' Failed' });
+                            if (sendError) {
+                                msg.error = err;
+                                msg.payload = operation.toLocaleUpperCase() + ' Failed';
+                                msg.success = false;
+                                send(msg);
+                            }
                             conn.end();
                             return;
                         }
@@ -524,6 +634,12 @@ module.exports = function (RED) {
                                 if (throwError) node.error(err, msg);
                             }
                             if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + ' Failed' });
+                            if (sendError) {
+                                msg.error = err;
+                                msg.payload = operation.toLocaleUpperCase() + ' Failed';
+                                msg.success = false;
+                                send(msg);
+                            }
                             conn.end();
                             return;
                         }
@@ -611,11 +727,14 @@ module.exports = function (RED) {
                                     if (err) {
                                         if (throwError) node.error(err, msg);
                                         if (showError) node.status({ fill: 'red', shape: 'ring', text: 'PUT Failed' });
+                                        // Handle the error for PUT operation
+                                        if (sendError) {
+                                            msg.error = err;
+                                            msg.payload = 'PUT operation failed.';
+                                            msg.success = false;
+                                            send(msg);
+                                        }
                                         conn.end();
-                                        msg.error = err;
-                                        msg.payload = 'PUT operation failed.';
-                                        msg.success = false;
-                                        send(msg);
                                         return;
                                     }
                             
@@ -624,11 +743,14 @@ module.exports = function (RED) {
                                         if (err) {
                                             if (throwError) node.error(err, msg);
                                             if (showError) node.status({ fill: 'red', shape: 'ring', text: 'RENAME Failed' });
-                                            conn.end();
-                                            msg.error = err;
-                                            msg.payload = 'RENAME operation failed.';
-                                            msg.success = false;
-                                            send(msg);
+                                            // Handle the error for RENAME operation
+                                            if (sendError) {
+                                                msg.error = err;
+                                                msg.payload = 'RENAME operation failed.';
+                                                msg.success = false;
+                                                send(msg);
+                                            }
+                                            conn.end();                                            
                                             return;
                                         }
                             
@@ -651,6 +773,12 @@ module.exports = function (RED) {
                 conn.on('error', function (err) {
                     if (throwError) node.error(err, msg);
                     if (showError) node.status({ fill: 'red', shape: 'ring', text: err.message });
+                    if (sendError) {
+                        msg.error = err;
+                        msg.payload = 'Connection Error';
+                        msg.success = false;
+                        send(msg);
+                    }
                     return;
                 });
 

--- a/src/advanced-ftp.js
+++ b/src/advanced-ftp.js
@@ -628,6 +628,9 @@ module.exports = function (RED) {
                                         if (throwError) node.error(err, msg);
                                         if (showError) node.status({ fill: 'red', shape: 'ring', text: 'PUT Failed' });
                                         conn.end();
+                                        msg.error = err;
+                                        msg.payload = 'PUT operation failed.';
+                                        send(msg);
                                         return;
                                     }
                             
@@ -637,6 +640,9 @@ module.exports = function (RED) {
                                             if (throwError) node.error(err, msg);
                                             if (showError) node.status({ fill: 'red', shape: 'ring', text: 'RENAME Failed' });
                                             conn.end();
+                                            msg.error = err;
+                                            msg.payload = 'RENAME operation failed.';
+                                            send(msg);
                                             return;
                                         }
                             

--- a/src/advanced-ftp.js
+++ b/src/advanced-ftp.js
@@ -19,7 +19,7 @@ module.exports = function (RED) {
     var ftp = require('ftp');
     var fs = require('fs')
 
-    //Funzione per la configurazione
+    // Function for configuration
     function AdvancedFtpNode(n) {
         RED.nodes.createNode(this, n);
         var credentials = RED.nodes.getCredentials(n.id) || {};
@@ -36,17 +36,17 @@ module.exports = function (RED) {
         };
     }
 
-    //Registra il Node
+    // Register the Node
     RED.nodes.registerType('advanced-ftp-config', AdvancedFtpNode, {
         credentials: {
             password: { type: 'password' }
         }
     });
 
-    //Funzione per il nodo FTP
+    // Function for the FTP node
     function AdvancedFtpInNode(n) {
         RED.nodes.createNode(this, n);
-        //Imposta le variabili locali
+        // Set local variables
         this.ftp = n.ftp;
         this.operation = n.operation;
         this.dataType = n.dataType;
@@ -64,10 +64,10 @@ module.exports = function (RED) {
 
         this.status({});
 
-        //Se la configurazione è presente continua
+        // If the configuration is present, continue
         if (this.ftpConfig) {
             var node = this;
-            //Il nodo ha ricevuto un input
+            // The node has received an input
             node.on('input', function (msg, send, done) {
 
                 node.status({});
@@ -75,27 +75,27 @@ module.exports = function (RED) {
                 // If this is pre-1.0, 'send' will be undefined, so fallback to node.send
                 send = send || function () { node.send.apply(node, arguments) }
 
-                //Crea un costruttore per il server ftp
+                // Create a constructor for the FTP server
                 var conn = new ftp();
                 
-                // Permetti all'utente di motificare le opzioni
+                // Allow the user to modify the options
                 var options = msg.options || node.ftpConfig.options;
 
                 delete msg.options;
 
-                //Il msg.filename è prioritario sul filename impostato nel nodo
+                // The msg.filename takes precedence over the filename set in the node
                 var filename = msg.filename || node.filename || '';
                 if (typeof filename != 'string') {
                     filename = '';
                 }
 
-                //Il msg.command è prioritario sul command impostato nel nodo
+                // The msg.command takes precedence over the command set in the node
                 var command = msg.command || node.command || '';
                 if (typeof command != 'string') {
                     command = '';
                 }
 
-                //Il msg.dataType è prioritario sul dataType impostato nel nodo
+                // The msg.dataType takes precedence over the dataType set in the node
                 var dataType = msg.dataType || node.dataType || '';
                 if (typeof dataType != 'string') {
                     dataType = 'binary';
@@ -103,65 +103,65 @@ module.exports = function (RED) {
 
                 dataType = dataType.toLocaleLowerCase();
 
-                //Il msg.localFilename è prioritario sul localFilename impostato nel nodo
+                // The msg.localFilename takes precedence over the localFilename set in the node
                 var localFilename = msg.localFilename || node.localFilename || '';
                 if (typeof localFilename != 'string') {
                     localFilename = '';
                 }
 
-                //Il msg.oldPath è prioritario sul oldPath impostato nel nodo
+                // The msg.oldPath takes precedence over the oldPath set in the node
                 var oldPath = msg.oldPath || msg.path || node.oldPath || '';
                 if (typeof oldPath != 'string') {
                     oldPath = '';
                 }
 
-                //Il msg.newPath è prioritario sul newPath impostato nel nodo
+                // The msg.newPath takes precedence over the newPath set in the node
                 var newPath = msg.newPath || msg.path || node.newPath || '';
                 if (typeof newPath != 'string') {
                     newPath = '';
                 }
 
-                //Il msg.workingDir è prioritario sul workingDir impostato nel nodo
+                // The msg.workingDir takes precedence over the workingDir set in the node
                 var workingDir = msg.workingDir || node.workingDir || '';
                 if (typeof workingDir != 'string') {
                     workingDir = '';
                 }
 
-                //Il msg.recursive è prioritario sul recursive impostato nel nodo
+                // The msg.recursive takes precedence over the recursive set in the node
                 var recursive = node.recursive;
 
                 if ((msg.recursive !== undefined) && (typeof msg.recursive === 'boolean')) {
                     recursive = msg.recursive;
                 }
 
-                //Il msg.useCompression è prioritario sul useCompression impostato nel nodo
+                // The msg.useCompression takes precedence over the useCompression set in the node
                 var useCompression = node.useCompression;
 
                 if ((msg.useCompression !== undefined) && (typeof msg.useCompression === 'boolean')) {
                     useCompression = msg.useCompression;
                 }
 
-                //Il msg.showError è prioritario sul showError impostato nel nodo
+                // The msg.showError takes precedence over the showError set in the node
                 var showError = node.showError;
 
                 if ((msg.showError !== undefined) && (typeof msg.showError === 'boolean')) {
                     showError = msg.showError;
                 }
 
-                //Il msg.throwError è prioritario sul throwError impostato nel nodo
+                // The msg.throwError takes precedence over the throwError set in the node
                 var throwError = node.throwError;
 
                 if ((msg.throwError !== undefined) && (typeof msg.throwError === 'boolean')) {
                     throwError = msg.throwError;
                 }
 
-                //Il msg.operation è prioritario sul operation impostato nel nodo
+                // The msg.operation takes precedence over the operation set in the node
                 var operation = msg.operation || node.operation || '';
                 if (typeof operation != 'string') {
                     operation = '';
                 }
 
-                //Il msg.abort è prioritario sul abort impostato nel nodo
+                // The msg.abort takes precedence over the abort set in the node
                 var abort = msg.abort;
 
                 this.abortCommand = function (err) {
@@ -193,23 +193,23 @@ module.exports = function (RED) {
                 } else {
                     operation = operation.toLocaleLowerCase();
 
-                    //Gestisci operation quando viene inviato tramite un oggetto json
+                    // Manage operation when sent via a JSON object
 
                     switch (operation) {
                         case 'status':
-                            // Non fare niente, non richiede parametri aggiuntivi
+                            // Do nothing, does not require additional parameters
                             break;
                         case 'list':
-                            // Non fare niente, non richiede parametri aggiuntivi
+                            // Do nothing, does not require additional parameters
                             break;
                         case 'listsafe':
-                            // Non fare niente, non richiede parametri aggiuntivi
+                            // Do nothing, does not require additional parameters
                             break;
                         case 'lastmod':
-                            // Non fare niente, non richiede parametri aggiuntivi
+                            // Do nothing, does not require additional parameters
                             break;
                         case 'size':
-                            // Non fare niente, non richiede parametri aggiuntivi
+                            // Do nothing, does not require additional parameters
                             break;
                         case 'site':
                             if (command === '') {
@@ -268,10 +268,17 @@ module.exports = function (RED) {
                             }
                             break;
                         case 'pwd':
-                            // Non fare niente, non richiede parametri aggiuntivi
+                            // Do nothing, does not require additional parameters
                             break;
                         case 'system':
-                            // Non fare niente, non richiede parametri aggiuntivi
+                            // Do nothing, does not require additional parameters
+                            break;
+                        case 'putrename':
+                            if (filename === '' || localFilename === '' || newPath === '') {
+                                if (throwError) node.error("Invalid Parameters for " + operation.toLocaleUpperCase());
+                                if (showError) node.status({ fill: 'red', shape: 'ring', text: operation.toLocaleUpperCase() + " :Invalid Parameters" });
+                                return;
+                            }
                             break;
                         default:
                             if (throwError) node.error("Invalid Command");
@@ -279,10 +286,10 @@ module.exports = function (RED) {
                             return;
                     }
 
-                    //Visulizza lo status del nodo
+                    // Display the status of the node
                     node.status({ fill: 'yellow', shape: 'ring', text: operation.toLocaleUpperCase() + ' Operation: ' + options.host + ':' + options.port });
 
-                    //Messaggi per le funzioni GET, PUT, APPEND, DELETE, LIST
+                    // Messages for the GET, PUT, APPEND, DELETE, LIST functions
                     this.sendMsg = function (err, result) {
 
                         if (err) {
@@ -350,7 +357,7 @@ module.exports = function (RED) {
                         }
                     };
 
-                    //Gestisci l'errore del' operazione GET
+                    // Handle the error of the GET operation
                     this.handleErrors = function (err) {
 
                         node.status({ fill: 'red', shape: 'ring', text: 'Something went wrong...' });
@@ -372,6 +379,7 @@ module.exports = function (RED) {
                     }
 
 
+                    // Handle the status response
                     this.sendStatus = function (err, result) {
                         if (err) {
                             if (done) {
@@ -400,6 +408,7 @@ module.exports = function (RED) {
                         send(msg);
                     };
 
+                    // Handle the paths for operations like rename, mkdir, rmdir
                     this.sendPaths = function (err) {
                         if (err) {
                             if (done) {
@@ -439,6 +448,7 @@ module.exports = function (RED) {
                         send(msg);
                     };
 
+                    // Set the data type
                     this.setDataType = function (err) {
                         if (err) {
                             if (done) {
@@ -455,6 +465,7 @@ module.exports = function (RED) {
 
                     };
 
+                    // Handle the last modified date
                     this.lastModified = function (err, date) {
                         if (err) {
                             if (done) {
@@ -478,6 +489,7 @@ module.exports = function (RED) {
                         send(msg);
                     };
 
+                    // Handle the size of a file
                     this.getSize = function (err, bytes) {
                         if (err) {
                             if (done) {
@@ -501,6 +513,7 @@ module.exports = function (RED) {
                         send(msg);
                     };
 
+                    // Handle the SITE command
                     this.siteCommand = function (err, response, result) {
                         if (err) {
                             if (done) {
@@ -593,11 +606,38 @@ module.exports = function (RED) {
                             case 'site':
                                 conn.site(command, node.siteCommand);
                                 break;
+                            case 'putrename':
+                                conn.put(localFilename, filename, useCompression, function (err) {
+                                    if (err) {
+                                        if (throwError) node.error(err, msg);
+                                        if (showError) node.status({ fill: 'red', shape: 'ring', text: 'PUT Failed' });
+                                        conn.end();
+                                        return;
+                                    }
+
+                                    conn.rename(filename, newPath, function (err) {
+                                        if (err) {
+                                            if (throwError) node.error(err, msg);
+                                            if (showError) node.status({ fill: 'red', shape: 'ring', text: 'RENAME Failed' });
+                                            conn.end();
+                                            return;
+                                        }
+
+                                        conn.end();
+                                        node.status({ fill: 'green', shape: 'ring', text: 'PUTRENAME Successful' });
+                                        msg.payload = 'PUTRENAME operation successful.';
+                                        msg.filename = filename;
+                                        msg.localFilename = localFilename;
+                                        msg.newPath = newPath;
+                                        send(msg);
+                                    });
+                                });
+                                break;
                         }
                     });
                 }
 
-                //La connessione al server ha riscontrato un errore
+                // The connection to the server encountered an error
                 conn.on('error', function (err) {
                     if (throwError) node.error(err, msg);
                     if (showError) node.status({ fill: 'red', shape: 'ring', text: err.message });
@@ -613,6 +653,7 @@ module.exports = function (RED) {
 
             });
         } else {
+            // Missing Advanced FTP configuration
             this.error('Missing Advanced Ftp configuration');
         }
 

--- a/src/advanced-ftp.js
+++ b/src/advanced-ftp.js
@@ -335,12 +335,6 @@ module.exports = function (RED) {
                             msg.filename = filename;
                             msg.localFilename = localFilename;
                             msg.payload = 'PUT operation successful.';
-                        } else if (operation == 'putrename') {
-                            conn.end();
-                            node.status({ fill: 'green', shape: 'ring', text: 'PUT Successful' });
-                            msg.filename = filename;
-                            msg.localFilename = localFilename;
-                            msg.payload = 'PUT operation successful.';
                         } else if (operation == 'append') {
                             conn.end();
                             node.status({ fill: 'green', shape: 'ring', text: 'APPEND Successful' });
@@ -433,13 +427,6 @@ module.exports = function (RED) {
                             conn.end();
                             node.status({ fill: 'green', shape: 'ring', text: 'RENAME Successful' });
                             msg.payload = 'RENAME operation successful.';
-                            msg.oldPath = oldPath;
-                            msg.newPath = newPath;
-                        }
-                        if (operation == 'putrename') {
-                            conn.end();
-                            node.status({ fill: 'green', shape: 'ring', text: 'RENAME Successful' });
-                            msg.payload = 'RENAME of PUTRENAME operation successful.';
                             msg.oldPath = oldPath;
                             msg.newPath = newPath;
                         }
@@ -619,10 +606,7 @@ module.exports = function (RED) {
                             case 'site':
                                 conn.site(command, node.siteCommand);
                                 break;
-                            case 'putrename':
-                                //conn.put(localFilename, filename, useCompression, node.sendMsg);
-                                //conn.rename(filename, newPath, node.sendPaths);
-                                
+                            case 'putrename':                               
                                 conn.put(localFilename, filename, useCompression, function (err) {
                                     if (err) {
                                         if (throwError) node.error(err, msg);
@@ -630,6 +614,7 @@ module.exports = function (RED) {
                                         conn.end();
                                         msg.error = err;
                                         msg.payload = 'PUT operation failed.';
+                                        msg.success = false;
                                         send(msg);
                                         return;
                                     }
@@ -642,6 +627,7 @@ module.exports = function (RED) {
                                             conn.end();
                                             msg.error = err;
                                             msg.payload = 'RENAME operation failed.';
+                                            msg.success = false;
                                             send(msg);
                                             return;
                                         }
@@ -649,6 +635,7 @@ module.exports = function (RED) {
                                         conn.end();
                                         node.status({ fill: 'green', shape: 'ring', text: 'PUTRENAME Successful' });
                                         msg.payload = 'PUTRENAME operation successful.';
+                                        msg.success = true;
                                         msg.filename = filename;
                                         msg.localFilename = localFilename;
                                         msg.newPath = newPath;

--- a/src/advanced-ftp.js
+++ b/src/advanced-ftp.js
@@ -329,7 +329,7 @@ module.exports = function (RED) {
                             } catch (err) {
                                 node.handleErrors(err);
                             }
-                        } else if (operation == 'put') {
+                        } else if (operation == 'put' || operation == 'putrename') {
                             conn.end();
                             node.status({ fill: 'green', shape: 'ring', text: 'PUT Successful' });
                             msg.filename = filename;
@@ -423,7 +423,7 @@ module.exports = function (RED) {
                             return;
                         }
 
-                        if (operation == 'rename') {
+                        if (operation == 'rename' || operation == 'putrename') {
                             conn.end();
                             node.status({ fill: 'green', shape: 'ring', text: 'RENAME Successful' });
                             msg.payload = 'RENAME operation successful.';
@@ -607,31 +607,8 @@ module.exports = function (RED) {
                                 conn.site(command, node.siteCommand);
                                 break;
                             case 'putrename':
-                                conn.put(localFilename, filename, useCompression, function (err) {
-                                    if (err) {
-                                        if (throwError) node.error(err, msg);
-                                        if (showError) node.status({ fill: 'red', shape: 'ring', text: 'PUT Failed' });
-                                        conn.end();
-                                        return;
-                                    }
-
-                                    conn.rename(filename, newPath, function (err) {
-                                        if (err) {
-                                            if (throwError) node.error(err, msg);
-                                            if (showError) node.status({ fill: 'red', shape: 'ring', text: 'RENAME Failed' });
-                                            conn.end();
-                                            return;
-                                        }
-
-                                        conn.end();
-                                        node.status({ fill: 'green', shape: 'ring', text: 'PUTRENAME Successful' });
-                                        msg.payload = 'PUTRENAME operation successful.';
-                                        msg.filename = filename;
-                                        msg.localFilename = localFilename;
-                                        msg.newPath = newPath;
-                                        send(msg);
-                                    });
-                                });
+                                conn.put(localFilename, filename, useCompression, node.sendMsg);
+                                conn.rename(oldPath, newPath, node.sendPaths);
                                 break;
                         }
                     });


### PR DESCRIPTION
1. **New `putrename` Operation**:
   - Added support for the `putrename` operation in the FTP node.
   - The operation first uploads a file (`PUT`) and then renames it (`RENAME`) on the FTP server.
   - Parameters required:
     - `msg.localFilename`: Path to the local file to upload.
     - `msg.filename`: Temporary name for the uploaded file on the server.
     - `msg.newPath`: Final name/path for the file on the server.

2. **New 'SendError' option**:
    - This allow the node to still send a messages when there is an error.
    
![image](https://github.com/user-attachments/assets/51508aab-f516-46f3-8ed8-96d90178f900)

Please review and merge this pull request. Let me know if any additional changes are required!
